### PR TITLE
fix: sends proper solution directory to vstest.discover_solution_tests

### DIFF
--- a/lua/neotest-dotnet/init.lua
+++ b/lua/neotest-dotnet/init.lua
@@ -24,14 +24,14 @@ local dap_settings = {
 local DotnetNeotestAdapter = { name = "neotest-dotnet" }
 
 function DotnetNeotestAdapter.root(path)
-  local solution = lib.files.match_root_pattern("*.sln")(path)
+  local solution_dir = lib.files.match_root_pattern("*.sln")(path)
     or lib.files.match_root_pattern("*.slnx")(path)
 
-  if solution then
-    vstest.discover_solution_tests(vim.fs.dirname(solution))
+  if solution_dir then
+    vstest.discover_solution_tests(solution_dir)
   end
 
-  return solution or lib.files.match_root_pattern("*.[cf]sproj")(path)
+  return solution_dir or lib.files.match_root_pattern("*.[cf]sproj")(path)
 end
 
 function DotnetNeotestAdapter.is_test_file(file_path)


### PR DESCRIPTION
This PR fixes a bug where the the parent of the solution directory is sent to `vstest.discover_solution_tests()`.

`lib.files.match_root_pattern` return the directory that contains the file matching the pattern.

Renamed variable to make it clearer what the variable contains